### PR TITLE
pocketchip-menu: Fix icon path in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -218,7 +218,7 @@ def draw_page(page_index):
             )
             app.addIcon(
                 Icon(
-                    img=BASEDIR + icon["icon"], 
+                    img=BASEDIR + "/" + icon["icon"],
                     pos=pos, 
                     size=size, 
                     page=Pages.HOME,


### PR DESCRIPTION
The icon path in main.py is not correct for me, it is showing as
/home/chip/pocketchip-menuicons/... This should correct it.

Signed-off-by: Chris Morgan <macromorgan@hotmail.com>