### PR TITLE
Settings: hook up backlight for settings page

### DIFF
--- a/Modules/GenWidgets/Widget.py
+++ b/Modules/GenWidgets/Widget.py
@@ -25,7 +25,7 @@ class Slider():
         
     def setValue(self, value):
         print('Setting the value to {}'.format(value))
-        self.value = value
+        self.value = int(round(value, 0))
 
     def update(self):
         self.handle_x = ((self.size[0]/self.max)*self.value) - (self.handle_width/2)

--- a/Modules/Screens/Settings.py
+++ b/Modules/Screens/Settings.py
@@ -1,6 +1,30 @@
 import pygame
 from Modules.Globals import *
 from Modules.GenWidgets.Widget import TextButton,Slider
+import dbus
+import os
+
+def get_backlight_name():
+    try:
+        return os.listdir('/sys/class/backlight')[0]
+    except:
+        return None #if none, should not show slider at all
+
+def get_backlight_max(backlight_name):
+    with open('/sys/class/backlight/'+backlight_name+'/max_brightness') as f:
+        max_brightness = int(f.readline())
+    return max_brightness
+
+def get_backlight_value(backlight_name):
+    with open('/sys/class/backlight/'+backlight_name+'/brightness') as f:
+        brightness = int(f.readline())
+    return brightness
+
+def set_backlight(backlight_name, value):
+    bus = dbus.SystemBus()
+    obj = bus.get_object('org.freedesktop.login1', '/org/freedesktop/login1/session/auto')
+    iface = dbus.Interface(obj, 'org.freedesktop.login1.Session')
+    iface.SetBrightness('backlight', backlight_name, value)
 
 class Settings():
     index = Pages.SETTINGS
@@ -10,36 +34,36 @@ class Settings():
         self.visible = False
         self.parent = parent
         self.image = assetpath('settingsBackground.png')
-        volume_slider = Slider(
+        self.backlight_name = get_backlight_name()
+        self.volume_slider = Slider(
             label='Volume',
             size=(200,40),
             pos=((pygame.display.Info().current_w/2) - 100, 150),
             value=75,
             icons=('volumeIconLo.png', 'volumeIconHi.png'),
-            function=lambda:print('clicked the slider')
+            function=lambda self=self:print('clicked the slider')
         )
-        brightness_slider = Slider(
-            label='Brightness',
-            size=(200,40),
-            pos=((pygame.display.Info().current_w/2) - 100, 200),
-            value=50,
-            icons=('brightnessIconLo.png', 'brightnessIconHi.png'),
-            function=lambda:print('clicked the slider')
-        )
+        if self.backlight_name is not None:
+            self.brightness_slider = Slider(
+                label='Brightness',
+                size=(200,40),
+                pos=((pygame.display.Info().current_w/2) - 100, 200),
+                value=get_backlight_value(self.backlight_name),
+                icons=('brightnessIconLo.png', 'brightnessIconHi.png'),
+                function=lambda self=self:set_backlight(self.backlight_name, self.brightness_slider.value),
+                minVal=0,
+                maxVal=10
+            )
         self.widgets = [
             TextButton(
                 text='Set volume to 100',
                 pos=(pygame.display.Info().current_w/2, 70),
-                function=lambda:volume_slider.setValue(100)
+                function=lambda:self.volume_slider.setValue(100)
             ),
-            TextButton(
-                text='Set brightness to 0',
-                pos=(pygame.display.Info().current_w/2, 120),
-                function=lambda:brightness_slider.setValue(0)
-            ),
-            volume_slider,
-            brightness_slider
+            self.volume_slider
         ]
+        if self.backlight_name is not None:
+            self.widgets.append(self.brightness_slider)
 
     def do(self, event):
         for widget in self.widgets:


### PR DESCRIPTION
This uses a simple os directory traversal in sysfs to find the
current value of the backlight, and it uses a dbus call to set the
value of the backlight (to avoid using root). I also changed the
slider class to avoid using floats.

Signed-off-by: Chris Morgan <macromorgan@hotmail.com>