### PR TITLE
Overhaul Screen Refresh Process/Thread Widgets

### DIFF
--- a/Modules/DBusMain.py
+++ b/Modules/DBusMain.py
@@ -1,0 +1,18 @@
+import __main__
+from threading import Thread
+import dbus
+from dbus.mainloop.glib import DBusGMainLoop
+from gi.repository import GLib
+from gi.repository import GObject
+
+try:
+    DBusGMainLoop(set_as_default=True)
+    GObject.threads_init()
+    dbus.mainloop.glib.threads_init()
+    dbus_loop = DBusGMainLoop()
+    DBUS_BUS = dbus.SystemBus(mainloop=dbus_loop)
+    MAINLOOP = GLib.MainLoop()
+    DBUS_THREAD = Thread(target=MAINLOOP.run, daemon=True)
+    DBUS_THREAD.start()
+except:
+    print("Error Loading DBus, functionality will be reduced!")

--- a/Modules/GenWidgets/Icon.py
+++ b/Modules/GenWidgets/Icon.py
@@ -19,11 +19,9 @@ class Icon(Button):
             self.size = self.image.get_rect()
         self.size = (self.size[0]+20, self.size[1]+20)
         self.function = function
-        
-        
         self.surface = pygame.Surface((self.size[0], self.size[1]), pygame.SRCALPHA)
         self.surface_rect = self.surface.get_rect(topleft=self.pos)
-    
+
     def draw(self, surf):
         # empty fill to clear what's been drawn
         self.surface.fill((0,0,0,0))
@@ -41,4 +39,4 @@ class Icon(Button):
             self.surface.blit(text, text_rect)
 
         surf.blit(self.surface, self.surface_rect)
-            
+

--- a/Modules/GenWidgets/Nav.py
+++ b/Modules/GenWidgets/Nav.py
@@ -18,7 +18,7 @@ class Nav():
                 page=Pages.APPS,
                 image='powerIcon.png',
                 pos=(
-                    EDGE_PADDING, 
+                    EDGE_PADDING,
                     self.parent.screen.get_height() - 22 - EDGE_PADDING
                 ),
                 size=(45,22),
@@ -31,7 +31,7 @@ class Nav():
                 page=Pages.POWER,
                 image='nextIcon.png',
                 pos=(
-                    self.parent.screen.get_width() - 64, 
+                    self.parent.screen.get_width() - 64,
                     self.parent.screen.get_height()/2 - 32
                 ),
                 size=(64,64),
@@ -46,7 +46,7 @@ class Nav():
                 page=Pages.APPS,
                 image='settingsIcon.png',
                 pos=(
-                    self.parent.screen.get_width() - 45 - EDGE_PADDING, 
+                    self.parent.screen.get_width() - 45 - EDGE_PADDING,
                     self.parent.screen.get_height() - 22 - EDGE_PADDING
                 ),
                 size=(45,22),
@@ -61,7 +61,7 @@ class Nav():
                 page=Pages.SETTINGS,
                 image='backIcon.png',
                 pos=(
-                    0, 
+                    0,
                     self.parent.screen.get_height()/2 - 32
                 ),
                 size=(64,64),
@@ -87,20 +87,23 @@ class Nav():
                 menu.active_page += 1
                 if menu.active_page >= len(menu.pages):
                     menu.active_page = len(menu.pages)
+
     def do(self, event):
         if self.parent.visible:
             for button in self.buttons:
                 button.do(event)
+        if self.visible:
+            if event.type == pygame.USEREVENT and 'type' in event.__dict__ and event.__dict__['type'] == 'widget_update':
+                for widget in self.widgets:
+                    if widget.page == self.parent.active_page or widget.persistent:
+                        widget.update()
 
     def update(self):
-        if self.visible:
-            # update widgets
-            for widget in self.widgets:
-                if widget.page == self.parent.active_page or widget.persistent:
-                    widget.update()
+        pass
 
     def draw(self, surf):
         if self.visible:
+            print('redrawing page')
             # draw page title
             font = pygame.font.Font(FONT_LATO,20)
             text = font.render(self.parent.pages[self.parent.active_page-1].title, True, (255, 255, 255))

--- a/Modules/GenWidgets/Nav.py
+++ b/Modules/GenWidgets/Nav.py
@@ -76,6 +76,7 @@ class Nav():
 
 
     def goToPage(self, menu, direction=None, page=None):
+        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
         if page and 1 <= page <= len(menu.pages):
             menu.active_page = page
         else:
@@ -93,17 +94,15 @@ class Nav():
             for button in self.buttons:
                 button.do(event)
         if self.visible:
-            if event.type == pygame.USEREVENT and 'type' in event.__dict__ and event.__dict__['type'] == 'widget_update':
-                for widget in self.widgets:
-                    if widget.page == self.parent.active_page or widget.persistent:
-                        widget.update()
+            for widget in self.widgets:
+                if widget.page == self.parent.active_page or widget.persistent:
+                    widget.update()
 
     def update(self):
         pass
 
     def draw(self, surf):
-        if self.visible:
-            print('redrawing page')
+        if self.visible is True:
             # draw page title
             font = pygame.font.Font(FONT_LATO,20)
             text = font.render(self.parent.pages[self.parent.active_page-1].title, True, (255, 255, 255))

--- a/Modules/GenWidgets/Widget.py
+++ b/Modules/GenWidgets/Widget.py
@@ -22,7 +22,7 @@ class Slider():
 
         self.handle_width = 10
         self.handle_x = ((self.size[0]/self.max)*self.value) - (self.handle_width/2)
-        
+
     def setValue(self, value):
         print('Setting the value to {}'.format(value))
         self.value = int(round(value, 0))
@@ -46,7 +46,7 @@ class Slider():
         font = pygame.font.Font(FONT_LATO,14)
         if self.label:
             text_string = '{}: {}'.format(self.label, self.value)
-        else: 
+        else:
             text_string = str(self.value)
         rendered_text = font.render(text_string, True, (255,255,255))
         text_rect = rendered_text.get_rect(midtop=(self.size[0]/2,0))
@@ -56,7 +56,7 @@ class Slider():
         if self.icons:
             icon_size = (24,24)
             positions = [self.pos, (self.pos[0] + self.size[0] - icon_size[0], self.pos[1])] # left, right
-            for index,icon in enumerate(self.icons): 
+            for index,icon in enumerate(self.icons):
                 icon_asset = pygame.image.load(assetpath(icon)).convert_alpha()
                 image = pygame.transform.scale(icon_asset, icon_size)
                 surf.blit(image, positions[index])
@@ -72,7 +72,7 @@ class Slider():
                 clicked_pos = mouse[0] - self.pos[0]
                 self.setValue((self.max/slider_width) * clicked_pos)
             if event.type == pygame.MOUSEBUTTONUP:
-                if self.function != None: 
+                if self.function != None:
                     print('clicked Slider "{}"'.format(self.label))
                     self.function()
 
@@ -109,7 +109,7 @@ class ConfirmDialog():
     def draw(self, surf):
         # empty fill to clear what's been drawn
         self.surface.fill((0,0,0,0))
-        
+
         # draw a background fill
         dialog_rect = pygame.Rect(0,0, self.size[0], self.size[1], topleft=(0,0))
         pygame.draw.rect(self.surface, (100,100,100), dialog_rect)
@@ -118,7 +118,7 @@ class ConfirmDialog():
             text = pygame.font.Font(FONT_LATO, 20).render(self.message, True, (255,255,255))
             if self.buttons:
                 text_rect = text.get_rect(center=(self.size[0]/2, 40))
-            else: 
+            else:
                 text_rect = text.get_rect(center=(self.size[0]/2, self.size[1]/2))
             self.surface.blit(text, text_rect)
 
@@ -132,7 +132,7 @@ class ConfirmDialog():
     def hide(self):
         self.visible = False
         self.parent.dialog = None
-    
+
     def do(self, event):
         for button in self.buttons:
             button.do(event)
@@ -143,15 +143,14 @@ class Button():
         self.pos = pos
         self.size = size
         self.function = function
-        
         self.surface = pygame.Surface(self.size, pygame.SRCALPHA)
         self.surface_rect = self.surface.get_rect(center=self.pos)
-    
+
     def do(self, event):
         if event.type == pygame.MOUSEBUTTONUP:
             mouse = pygame.mouse.get_pos()
             if within_bounds(mouse, self.surface_rect):
-                if self.function != None: 
+                if self.function != None:
                     print('clicked Button "{}"'.format(self.function))
                     self.function()
 

--- a/Modules/GenWidgets/Widget.py
+++ b/Modules/GenWidgets/Widget.py
@@ -25,7 +25,7 @@ class Slider():
         
     def setValue(self, value):
         print('Setting the value to {}'.format(value))
-        self.value = value
+        self.value = int(round(value, 0))
 
     def update(self):
         self.handle_x = ((self.size[0]/self.max)*self.value) - (self.handle_width/2)

--- a/Modules/GenWidgets/Widget.py
+++ b/Modules/GenWidgets/Widget.py
@@ -71,10 +71,12 @@ class Slider():
                 slider_width = self.size[0]
                 clicked_pos = mouse[0] - self.pos[0]
                 self.setValue((self.max/slider_width) * clicked_pos)
+                pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
             if event.type == pygame.MOUSEBUTTONUP:
                 if self.function != None:
                     print('clicked Slider "{}"'.format(self.label))
                     self.function()
+                    pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
 
 class ConfirmDialog():
     def __init__(self, parent=None, message='Are you sure?', options=None):
@@ -128,10 +130,12 @@ class ConfirmDialog():
 
     def show(self):
         self.visible = True
+        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
 
     def hide(self):
         self.visible = False
         self.parent.dialog = None
+        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
 
     def do(self, event):
         for button in self.buttons:
@@ -164,7 +168,6 @@ class TextButton():
         self.fillcolor = fillcolor
         self.bordercolor = bordercolor
         self.textcolor = textcolor
-        
 
         if self.text:
             self.rendered_text = pygame.font.Font(FONT_LATO,20).render(self.text, True, self.textcolor)
@@ -172,10 +175,10 @@ class TextButton():
             # if we're not using a specific size, work it out based on the text
             if not self.size:
                 self.size = (
-                    self.rendered_text.get_width() + BUTTON_PADDING[0] + BUTTON_PADDING[2], 
+                    self.rendered_text.get_width() + BUTTON_PADDING[0] + BUTTON_PADDING[2],
                     self.rendered_text.get_height() + BUTTON_PADDING[1] + BUTTON_PADDING[3]
                 )
-            
+
         self.surface = pygame.Surface(self.size, pygame.SRCALPHA)
         self.surface_rect = pygame.Rect(self.pos[0], self.pos[1], self.size[0], self.size[1])
         self.surface_rect.center=self.pos
@@ -192,7 +195,7 @@ class TextButton():
         # draw the text
         if self.rendered_text:
             self.surface.blit(
-                self.rendered_text, 
+                self.rendered_text,
                 (
                     (self.size[0]/2)-(self.rendered_text.get_width()/2),
                     (self.size[1]/2)-(self.rendered_text.get_height()/2)
@@ -200,13 +203,14 @@ class TextButton():
             )
         # blit button to surf
         surf.blit(self.surface, self.surface_rect)
-    
+
     def do(self, event):
         if event.type == pygame.MOUSEBUTTONUP:
             if within_bounds(pygame.mouse.get_pos(), self.surface_rect):
                 if self.function != None:
                     print('clicked TextButton "{}"'.format(self.text))
                     self.function()
+                    pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
 
 class PageButton(Button):
     def __init__(self, parent=None, image=None, pos=(0,0), size=(0,0), page=None, function=None):
@@ -218,7 +222,7 @@ class PageButton(Button):
         self.function = function
         self.surface = pygame.Surface(self.size, pygame.SRCALPHA)
         self.surface_rect = self.surface.get_rect(topleft=self.pos)
-    
+
     def draw(self, surf):
         # empty fill to clear what's been drawn
         self.surface.fill((0,0,0,0))

--- a/Modules/NavWidgets/Battery.py
+++ b/Modules/NavWidgets/Battery.py
@@ -18,7 +18,7 @@ def random_battery(charging, capacity):
     while True:
         charging.value = 0
         capacity.value = random.randint(0,100)
-        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="widget_update"))
+        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
         time.sleep(60)
 
 class Battery(Widget):
@@ -52,7 +52,6 @@ class Battery(Widget):
 #        commented for testing
 #        if self.battery_present is False or self.persistent is False:
 #            return
-        self.parent.needs_refresh = True
         if self.battery_charging.value == 1:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-charging.png')).convert_alpha(), self.size)
             return

--- a/Modules/NavWidgets/Battery.py
+++ b/Modules/NavWidgets/Battery.py
@@ -1,57 +1,76 @@
 import pygame
 from Modules.Globals import *
+import Modules.DBusMain as DBusMain
+import dbus
 from Modules.GenWidgets.Widget import *
-from threading import Thread
 from multiprocessing import Value
-
-try:
-    import psutil
-except:
-    print("Library psutil missing")
-
-#these are for dummy battery testing
-import time
-import random
-
-#test process to update battery every few seconds
-def random_battery(charging, capacity):
-    while True:
-        charging.value = 0
-        capacity.value = random.randint(0,100)
-        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
-        time.sleep(60)
 
 class Battery(Widget):
     def __init__(self, parent=None):
         self.parent = parent
         self.size = (24, 24)
         self.pos = (EDGE_PADDING, EDGE_PADDING)
-        self.battery_present = False
         self.image = None
         self.page = None
         self.persistent = True
         self.battery_capacity = Value('i', 100)
         self.battery_charging = Value('i', 1)
-        self.battery_thread = Thread(target=random_battery, args=(self.battery_charging, self.battery_capacity), daemon=True)
 
         try:
-            if psutil.sensors_battery() is not None:
-                self.battery_present = True
-                self.battery_thread.start()
-
-#            added for testing
-            else:
-                self.battery_thread.start()
+            if self.check_battery():
+                self.persistent = True
+                self.get_battery_details(self.battery_charging, self.battery_capacity)
+                DBusMain.DBUS_BUS.add_signal_receiver(self.dbus_signal_handler,
+                                                      bus_name='org.freedesktop.UPower',
+                                                      dbus_interface='org.freedesktop.DBus.Properties',
+                                                      signal_name='PropertiesChanged',
+                                                      path='/org/freedesktop/UPower/devices/DisplayDevice')
         except:
-#            commented for testing
-#            self.persistent = False
-#            added for testing
-            self.battery_thread.start()
+            self.persistent = False
+
+    def check_battery(self):
+        proxy = DBusMain.DBUS_BUS.get_object('org.freedesktop.UPower',
+                               '/org/freedesktop/UPower/devices/DisplayDevice')
+        powerdev = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+        return bool(powerdev.Get('org.freedesktop.UPower.Device','IsPresent'))
+
+    def dbus_signal_handler(self, interface, data, type):
+        update = False
+        if 'State' in data and int(data['State']) != self.battery_charging.value:
+            self.battery_charging.value = int(data['State'])
+            update = True
+        if 'Percentage' in data and int(data['Percentage']) != self.battery_capacity.value:
+            self.battery_capacity.value = int(data['Percentage'])
+            update = True
+        if update is True:
+            pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
+            update = False
+        return
+
+    def get_battery_details(self, charging, capacity):
+        proxy = DBusMain.DBUS_BUS.get_object('org.freedesktop.UPower',
+                               '/org/freedesktop/UPower/devices/DisplayDevice')
+        getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+        update_battery = False
+        try:
+            new_capacity = int(getmanager.Get('org.freedesktop.UPower.Device', 'Percentage'))
+            if new_capacity != capacity.value:
+                capacity.value = new_capacity
+                update_battery = True
+            new_status = int(getmanager.Get('org.freedesktop.UPower.Device','State'))
+            if new_status != charging.value:
+                charging.value = new_status
+                update_battery = True
+        except:
+            print("Error reading battery")
+        if update_battery is True:
+            pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
+            update_battery = False
+        return None
 
     def update(self):
-#        commented for testing
-#        if self.battery_present is False or self.persistent is False:
-#            return
+        if self.persistent is False:
+            return
         if self.battery_charging.value == 1:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-charging.png')).convert_alpha(), self.size)
             return

--- a/Modules/NavWidgets/Battery.py
+++ b/Modules/NavWidgets/Battery.py
@@ -1,8 +1,25 @@
 import pygame
 from Modules.Globals import *
 from Modules.GenWidgets.Widget import *
-if IS_LINUX:
+from threading import Thread
+from multiprocessing import Value
+
+try:
     import psutil
+except:
+    print("Library psutil missing")
+
+#these are for dummy battery testing
+import time
+import random
+
+#test process to update battery every few seconds
+def random_battery(charging, capacity):
+    while True:
+        charging.value = 0
+        capacity.value = random.randint(0,100)
+        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="widget_update"))
+        time.sleep(60)
 
 class Battery(Widget):
     def __init__(self, parent=None):
@@ -12,34 +29,43 @@ class Battery(Widget):
         self.battery_present = False
         self.image = None
         self.page = None
-        self.persistent = True # always draw
-        
-        if IS_LINUX:
+        self.persistent = True
+        self.battery_capacity = Value('i', 100)
+        self.battery_charging = Value('i', 1)
+        self.battery_thread = Thread(target=random_battery, args=(self.battery_charging, self.battery_capacity), daemon=True)
+
+        try:
             if psutil.sensors_battery() is not None:
                 self.battery_present = True
-        else:
-            # on other platforms just show an icon 
-            self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-100.png')).convert_alpha(), self.size)
-    def update(self):
-        if self.battery_present is False:
-            return
+                self.battery_thread.start()
 
-        battery_data = psutil.sensors_battery()
-        if battery_data is None:
-            return
-        if battery_data.power_plugged is True:
+#            added for testing
+            else:
+                self.battery_thread.start()
+        except:
+#            commented for testing
+#            self.persistent = False
+#            added for testing
+            self.battery_thread.start()
+
+    def update(self):
+#        commented for testing
+#        if self.battery_present is False or self.persistent is False:
+#            return
+        self.parent.needs_refresh = True
+        if self.battery_charging.value == 1:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-charging.png')).convert_alpha(), self.size)
             return
-        if battery_data.percent > 75:
+        if self.battery_capacity.value > 75:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-100.png')).convert_alpha(), self.size)
             return
-        if battery_data.percent > 50:
+        if self.battery_capacity.value > 50:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-75.png')).convert_alpha(), self.size)
             return
-        if battery_data.percent > 25:
+        if self.battery_capacity.value > 25:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-50.png')).convert_alpha(), self.size)
             return
         else:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-25.png')).convert_alpha(), self.size)
-
+            return
 

--- a/Modules/NavWidgets/Bluetooth.py
+++ b/Modules/NavWidgets/Bluetooth.py
@@ -12,7 +12,7 @@ import random
 def random_bluetooth(connect):
     while True:
         connect.value = random.randint(0,1)
-        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="widget_update"))
+        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
         time.sleep(30)
 
 class Bluetooth(Widget):
@@ -33,7 +33,6 @@ class Bluetooth(Widget):
 #        commented out for testing
 #        if self.bt_device is None or self.persistent is False:
 #            return
-        self.parent.needs_refresh = True
         if self.bluetooth_connect.value == 0:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('bluetooth-disconnected.png')).convert_alpha(), self.size)
             return

--- a/Modules/NavWidgets/Bluetooth.py
+++ b/Modules/NavWidgets/Bluetooth.py
@@ -1,10 +1,19 @@
 import pygame
 from Modules.Globals import *
 from Modules.GenWidgets.Widget import *
+from threading import Thread
+from multiprocessing import Value
 
-if IS_LINUX:
-    # specific imports here
-    pass
+#these are for dummy signal testing
+import time
+import random
+
+#test process to update bluetooth every few seconds
+def random_bluetooth(connect):
+    while True:
+        connect.value = random.randint(0,1)
+        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="widget_update"))
+        time.sleep(30)
 
 class Bluetooth(Widget):
     def __init__(self, parent=None):
@@ -13,20 +22,21 @@ class Bluetooth(Widget):
         self.pos = (self.parent.parent.screen.get_width() - self.size[0] - SPACE_PADDING - self.parent.widgets[1].size[0] - EDGE_PADDING, EDGE_PADDING)
         self.image = None
         self.page = None
-        self.persistent = True # always draw
+        self.persistent = True
         self.bt_device = None
+        self.bluetooth_connect = Value('i', 1)
+        self.bluetooth_thread = Thread(target=random_bluetooth, args=(self.bluetooth_connect,), daemon=True)
 
-        if IS_LINUX:
-           # init the bt icon here
-           # self.bt_device = Foo
-           pass
-        else:
-            # on other platforms just show an icon 
-            self.image = pygame.transform.scale(pygame.image.load(assetpath('bluetooth-connected.png')).convert_alpha(), self.size)
+        self.bluetooth_thread.start()
 
     def update(self):
-        if self.bt_device is None:
+#        commented out for testing
+#        if self.bt_device is None or self.persistent is False:
+#            return
+        self.parent.needs_refresh = True
+        if self.bluetooth_connect.value == 0:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('bluetooth-disconnected.png')).convert_alpha(), self.size)
             return
         else:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('bluetooth-connected.png')).convert_alpha(), self.size)
+            return

--- a/Modules/NavWidgets/Bluetooth.py
+++ b/Modules/NavWidgets/Bluetooth.py
@@ -1,19 +1,9 @@
 import pygame
 from Modules.Globals import *
+import Modules.DBusMain as DBusMain
+import dbus
 from Modules.GenWidgets.Widget import *
-from threading import Thread
 from multiprocessing import Value
-
-#these are for dummy signal testing
-import time
-import random
-
-#test process to update bluetooth every few seconds
-def random_bluetooth(connect):
-    while True:
-        connect.value = random.randint(0,1)
-        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
-        time.sleep(30)
 
 class Bluetooth(Widget):
     def __init__(self, parent=None):
@@ -22,17 +12,61 @@ class Bluetooth(Widget):
         self.pos = (self.parent.parent.screen.get_width() - self.size[0] - SPACE_PADDING - self.parent.widgets[1].size[0] - EDGE_PADDING, EDGE_PADDING)
         self.image = None
         self.page = None
-        self.persistent = True
+        self.persistent = False
         self.bt_device = None
-        self.bluetooth_connect = Value('i', 1)
-        self.bluetooth_thread = Thread(target=random_bluetooth, args=(self.bluetooth_connect,), daemon=True)
+        self.bluetooth_connect = Value('i', 0)
+        self.bluetooth_power = Value('i', 1)
 
-        self.bluetooth_thread.start()
+        try:
+            self.get_bluetooth_device()
+            self.get_bluetooth_state()
+            DBusMain.DBUS_BUS.add_signal_receiver(self.dbus_signal_handler,
+                                                  bus_name='org.bluez',
+                                                  dbus_interface='org.freedesktop.DBus.Properties',
+                                                  signal_name='PropertiesChanged',
+                                                  path=self.bt_device)
+            self.persistent = True
+        except:
+            self.persistent = False
+
+    def dbus_signal_handler(self, interface, data, type):
+        update = False
+        if 'Powered' in data and int(data['Powered']) != self.bluetooth_power.value:
+            self.bluetooth_power.value = int(data['Powered'])
+            update = True
+        if 'Connected' in data and int(data['Connected']) != self.bluetooth_connect.value:
+            self.bluetooth_connect.value = int(data['Connected'])
+            update = True
+        if update is True:
+            pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
+            update = False
+        return
+
+    def get_bluetooth_device(self):
+        proxy = DBusMain.DBUS_BUS.get_object('org.bluez','/')
+        get_manager = dbus.Interface(proxy, 'org.freedesktop.DBus.ObjectManager')
+        objects = get_manager.GetManagedObjects()
+        for item in objects:
+            if 'org.bluez.Adapter1' in objects[item]:
+                self.bt_device = item
+
+    def get_bluetooth_state(self):
+        try:
+            proxy = DBusMain.DBUS_BUS.get_object('org.bluez',self.bt_device)
+            get_manager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+            self.bluetooth_power.value = int(get_manager.Get('org.bluez.Adapter1','Powered'))
+        except:
+            self.bluetooth_power.value = 0
+        try:
+            proxy = DBusMain.DBUS_BUS.get_object('org.bluez',bt_object_path)
+            get_manager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+            self.bluetooth_connect.value = int(get_manager.Get('org.bluez.Device1','Connected'))
+        except:
+            self.bluetooth_connect.value = 0
 
     def update(self):
-#        commented out for testing
-#        if self.bt_device is None or self.persistent is False:
-#            return
+        if self.bt_device is None or self.persistent is False:
+            return
         if self.bluetooth_connect.value == 0:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('bluetooth-disconnected.png')).convert_alpha(), self.size)
             return

--- a/Modules/NavWidgets/Wifi.py
+++ b/Modules/NavWidgets/Wifi.py
@@ -1,9 +1,25 @@
 import pygame
 from Modules.Globals import *
 from Modules.GenWidgets.Widget import *
+from threading import Thread
+from multiprocessing import Value
 
-if IS_LINUX:
+try:
     from NetworkManager import NetworkManager
+except:
+    print("Network Manager Not Found!")
+
+#these are for dummy signal testing
+import time
+import random
+
+#test process to update wifi every few seconds
+def random_signal_strength(connect, signal):
+    while True:
+        connect.value = 1
+        signal.value = random.randint(0,100)
+        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="widget_update"))
+        time.sleep(10)
 
 class Wifi(Widget):
     def __init__(self, parent=None):
@@ -12,33 +28,39 @@ class Wifi(Widget):
         self.pos = (self.parent.parent.screen.get_width() - self.size[0] - EDGE_PADDING, EDGE_PADDING)
         self.image = None
         self.page = None
-        self.persistent = True # always draw
+        self.persistent = True
         self.wifi_device = None
+        self.wifi_signal = Value('i', 100)
+        self.wifi_connect = Value('i', 1)
+        self.wifi_thread = Thread(target=random_signal_strength, args=(self.wifi_connect, self.wifi_signal), daemon=True)
 
-        if IS_LINUX:
-            try:
-                for device in NetworkManager.GetAllDevices():
-                    if device.DeviceType == 2:
-                        self.wifi_device = device
-            except:
-                self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-disconnected.png')).convert_alpha(), self.size)
-        else:
-            # on other platforms just show an icon
-            self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-100.png')).convert_alpha(), self.size)
+        try:
+            for device in NetworkManager.GetAllDevices():
+                if device.DeviceType == 2:
+                    self.wifi_device = device
+                    self.wifi_thread.start()
+        except:
+#            commented out for testing
+#            self.persistent = False
+
+#            added for testing
+             self.wifi_thread.start()
 
     def update(self):
-        if self.wifi_device is None:
-            return
-        if self.wifi_device.ActiveConnection is None:
+#        commented out for testing
+#        if self.wifi_device is None or self.persistent is False:
+#            return
+        self.parent.needs_refresh = True
+        if self.wifi_connect.value == 0:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-disconnected.png')).convert_alpha(), self.size)
             return
-        if self.wifi_device.ActiveConnection.Devices[0].ActiveAccessPoint.Strength > 75:
+        if self.wifi_signal.value > 75:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-100.png')).convert_alpha(), self.size)
             return
-        if self.wifi_device.ActiveConnection.Devices[0].ActiveAccessPoint.Strength > 50:
+        if self.wifi_signal.value > 50:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-75.png')).convert_alpha(), self.size)
             return
-        if self.wifi_device.ActiveConnection.Devices[0].ActiveAccessPoint.Strength > 25:
+        if self.wifi_signal.value > 25:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-50.png')).convert_alpha(), self.size)
             return
         else:

--- a/Modules/NavWidgets/Wifi.py
+++ b/Modules/NavWidgets/Wifi.py
@@ -16,11 +16,14 @@ class Wifi(Widget):
         self.wifi_device = None
 
         if IS_LINUX:
-            for device in NetworkManager.GetAllDevices():
-                if device.DeviceType == 2:
-                    self.wifi_device = device
+            try:
+                for device in NetworkManager.GetAllDevices():
+                    if device.DeviceType == 2:
+                        self.wifi_device = device
+            except:
+                self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-disconnected.png')).convert_alpha(), self.size)
         else:
-            # on other platforms just show an icon 
+            # on other platforms just show an icon
             self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-100.png')).convert_alpha(), self.size)
 
     def update(self):

--- a/Modules/NavWidgets/Wifi.py
+++ b/Modules/NavWidgets/Wifi.py
@@ -18,7 +18,7 @@ def random_signal_strength(connect, signal):
     while True:
         connect.value = 1
         signal.value = random.randint(0,100)
-        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="widget_update"))
+        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
         time.sleep(10)
 
 class Wifi(Widget):
@@ -50,7 +50,6 @@ class Wifi(Widget):
 #        commented out for testing
 #        if self.wifi_device is None or self.persistent is False:
 #            return
-        self.parent.needs_refresh = True
         if self.wifi_connect.value == 0:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-disconnected.png')).convert_alpha(), self.size)
             return

--- a/Modules/Screens/Apps.py
+++ b/Modules/Screens/Apps.py
@@ -3,7 +3,6 @@ import os
 from Modules.Globals import *
 from Modules.GenWidgets.Icon import *
 
-
 class Apps():
     index = Pages.APPS
     title = 'Apps'
@@ -26,7 +25,7 @@ class Apps():
         self.parent = parent
         self.image = assetpath('mainBackground.png')
         self.collate_apps()
-     
+
         wrap_at = 3
         wrap_counter = -1
         start_x = 80 # can probably calculate this to make this more scalable.
@@ -42,7 +41,7 @@ class Apps():
                 wrap_counter += 1
                 row_offset = start_y + (row_height * wrap_counter)
             else:
-                col_offset += col_width # new col 
+                col_offset += col_width # new col
 
             pos = (col_offset, row_offset)
             size = (64, 64)
@@ -57,11 +56,10 @@ class Apps():
                 )
             )
 
-
     def do(self, event):
         for icon in self.icons:
             icon.do(event)
-                        
+
     def update(self):
         pass
 

--- a/Modules/Screens/Power.py
+++ b/Modules/Screens/Power.py
@@ -68,7 +68,7 @@ class Power():
                 size=icon_size,
                 function=icon_data[3],
                 pos=(
-                    int(x_padding * (index + 1)) + (icon_size[0] * index), 
+                    int(x_padding * (index + 1)) + (icon_size[0] * index),
                     int(y_padding)
                 )
             ))
@@ -88,6 +88,6 @@ class Power():
     def draw(self, surf):
         for icon in self.icons:
             icon.draw(surf)
-    
+
 if __name__ == '__main__':
     pass

--- a/Modules/Screens/Settings.py
+++ b/Modules/Screens/Settings.py
@@ -1,6 +1,30 @@
 import pygame
 from Modules.Globals import *
 from Modules.GenWidgets.Widget import TextButton,Slider
+import dbus
+import os
+
+def get_backlight_name():
+    try:
+        return os.listdir('/sys/class/backlight')[0]
+    except:
+        return None #if none, should not show slider at all
+
+def get_backlight_max(backlight_name):
+    with open('/sys/class/backlight/'+backlight_name+'/max_brightness') as f:
+        max_brightness = int(f.readline())
+    return max_brightness
+
+def get_backlight_value(backlight_name):
+    with open('/sys/class/backlight/'+backlight_name+'/brightness') as f:
+        brightness = int(f.readline())
+    return brightness
+
+def set_backlight(backlight_name, value):
+    bus = dbus.SystemBus()
+    obj = bus.get_object('org.freedesktop.login1', '/org/freedesktop/login1/session/auto')
+    iface = dbus.Interface(obj, 'org.freedesktop.login1.Session')
+    iface.SetBrightness('backlight', backlight_name, value)
 
 class Settings():
     index = Pages.SETTINGS
@@ -10,36 +34,36 @@ class Settings():
         self.visible = False
         self.parent = parent
         self.image = assetpath('settingsBackground.png')
-        volume_slider = Slider(
+        self.backlight_name = get_backlight_name()
+        self.volume_slider = Slider(
             label='Volume',
             size=(200,40),
             pos=((pygame.display.Info().current_w/2) - 100, 150),
             value=75,
             icons=('volumeIconLo.png', 'volumeIconHi.png'),
-            function=lambda:print('clicked the slider')
+            function=lambda self=self:print('clicked the slider')
         )
-        brightness_slider = Slider(
-            label='Brightness',
-            size=(200,40),
-            pos=((pygame.display.Info().current_w/2) - 100, 200),
-            value=50,
-            icons=('brightnessIconLo.png', 'brightnessIconHi.png'),
-            function=lambda:print('clicked the slider')
-        )
+        if self.backlight_name is not None:
+            self.brightness_slider = Slider(
+                label='Brightness',
+                size=(200,40),
+                pos=((pygame.display.Info().current_w/2) - 100, 200),
+                value=get_backlight_value(self.backlight_name),
+                icons=('brightnessIconLo.png', 'brightnessIconHi.png'),
+                function=lambda self=self:set_backlight(self.backlight_name, self.brightness_slider.value),
+                minVal=0,
+                maxVal=10
+            )
         self.widgets = [
             TextButton(
                 text='Set volume to 100',
                 pos=(pygame.display.Info().current_w/2, 70),
-                function=lambda:volume_slider.setValue(100)
+                function=lambda:self.volume_slider.setValue(100)
             ),
-            TextButton(
-                text='Set brightness to 0',
-                pos=(pygame.display.Info().current_w/2, 120),
-                function=lambda:brightness_slider.setValue(0)
-            ),
-            volume_slider,
-            brightness_slider
+            self.volume_slider
         ]
+        if self.backlight_name is not None:
+            self.widgets.append(self.brightness_slider)
 
     def do(self, event):
         for widget in self.widgets:

--- a/dbustest.py
+++ b/dbustest.py
@@ -4,68 +4,95 @@ import dbus
 bus = dbus.SystemBus()
 
 def get_active_wifis():
-	array_of_wifi_devs = []
-	proxy = bus.get_object('org.freedesktop.NetworkManager',
-		'/org/freedesktop/NetworkManager')
-	getmanager = dbus.Interface(proxy, 'org.freedesktop.NetworkManager')
-	devices = getmanager.GetDevices()
-	for device in devices:
-		deviceobject = bus.get_object('org.freedesktop.NetworkManager',device)
-		deviceinterface = dbus.Interface(deviceobject, dbus_interface='org.freedesktop.DBus.Properties')
-		if deviceinterface.Get('org.freedesktop.NetworkManager.Device', 'DeviceType') == 2:
-			array_of_wifi_devs.append(device)
+    array_of_wifi_devs = []
+    proxy = bus.get_object('org.freedesktop.NetworkManager',
+        '/org/freedesktop/NetworkManager')
+    getmanager = dbus.Interface(proxy, 'org.freedesktop.NetworkManager')
+    devices = getmanager.GetDevices()
+    for device in devices:
+        deviceobject = bus.get_object('org.freedesktop.NetworkManager',device)
+        deviceinterface = dbus.Interface(deviceobject, dbus_interface='org.freedesktop.DBus.Properties')
+        if deviceinterface.Get('org.freedesktop.NetworkManager.Device', 'DeviceType') == 2:
+            array_of_wifi_devs.append(device)
 
-	return array_of_wifi_devs
+    return array_of_wifi_devs
 
 def get_scan_results(array_of_wifi_devs):
-	array_of_aps = []
-	for device in array_of_wifi_devs:
-		deviceobject = bus.get_object('org.freedesktop.NetworkManager',device)
-		deviceinterface = dbus.Interface(deviceobject, dbus_interface='org.freedesktop.NetworkManager.Device.Wireless')
-		for accesspoint in deviceinterface.GetAllAccessPoints():
-			array_of_aps.append(str(accesspoint))
-	return array_of_aps
+    array_of_aps = []
+    for device in array_of_wifi_devs:
+        deviceobject = bus.get_object('org.freedesktop.NetworkManager',device)
+        deviceinterface = dbus.Interface(deviceobject, dbus_interface='org.freedesktop.NetworkManager.Device.Wireless')
+        for accesspoint in deviceinterface.GetAllAccessPoints():
+            array_of_aps.append(str(accesspoint))
+    return array_of_aps
 
 def human_readable_ap_info(array_of_aps):
-	array_of_readable_aps = []
-	for accesspoint in array_of_aps:
-		apobject = bus.get_object('org.freedesktop.NetworkManager',accesspoint)
-		apinterface = dbus.Interface(apobject,dbus_interface='org.freedesktop.DBus.Properties')
-		ap = apinterface.GetAll('org.freedesktop.NetworkManager.AccessPoint')
-		ap_info = {}
-		ap_info['name'] = ''.join([chr(byte) for byte in ap['Ssid']])
-		ap_info['strength'] = int(ap['Strength'])
-		if int(ap['Flags']) & 0x1 == 1:
-			ap_info['encrypted'] = True
-		else:
-			ap_info['encrypted'] = False
-		array_of_readable_aps.append(ap_info)
-	return array_of_readable_aps
+    array_of_readable_aps = []
+    for accesspoint in array_of_aps:
+        apobject = bus.get_object('org.freedesktop.NetworkManager',accesspoint)
+        apinterface = dbus.Interface(apobject,dbus_interface='org.freedesktop.DBus.Properties')
+        ap = apinterface.GetAll('org.freedesktop.NetworkManager.AccessPoint')
+        ap_info = {}
+        ap_info['name'] = ''.join([chr(byte) for byte in ap['Ssid']])
+        ap_info['strength'] = int(ap['Strength'])
+        if int(ap['Flags']) & 0x1 == 1:
+            ap_info['encrypted'] = True
+        else:
+            ap_info['encrypted'] = False
+        array_of_readable_aps.append(ap_info)
+    return array_of_readable_aps
 
 def get_active_wifi_connection():
-	proxy = bus.get_object('org.freedesktop.NetworkManager',
-		'/org/freedesktop/NetworkManager')
-	getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
-	for connection in getmanager.Get('org.freedesktop.NetworkManager', 'ActiveConnections'):
-		connectionobject = bus.get_object('org.freedesktop.NetworkManager',
-					connection)
-		conmanager = dbus.Interface(connectionobject, 'org.freedesktop.DBus.Properties')
-		if conmanager.Get('org.freedesktop.NetworkManager.Connection.Active', 'State') in [1,2,3] and \
-			conmanager.Get('org.freedesktop.NetworkManager.Connection.Active','Type') == '802-11-wireless':
-			return [str(conmanager.Get('org.freedesktop.NetworkManager.Connection.Active','SpecificObject'))]
+    proxy = bus.get_object('org.freedesktop.NetworkManager',
+        '/org/freedesktop/NetworkManager')
+    getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+    for connection in getmanager.Get('org.freedesktop.NetworkManager', 'ActiveConnections'):
+        connectionobject = bus.get_object('org.freedesktop.NetworkManager',
+                    connection)
+        conmanager = dbus.Interface(connectionobject, 'org.freedesktop.DBus.Properties')
+        if conmanager.Get('org.freedesktop.NetworkManager.Connection.Active', 'State') in [1,2,3] and \
+            conmanager.Get('org.freedesktop.NetworkManager.Connection.Active','Type') == '802-11-wireless':
+            return [str(conmanager.Get('org.freedesktop.NetworkManager.Connection.Active','SpecificObject'))]
 
 def initiate_ap_scan(array_of_wifi_devs, current_time_monotonic=None):
-	last_scan_times_monotonic = []
-	for wifi_dev in array_of_wifi_devs:
-		proxy = bus.get_object('org.freedesktop.NetworkManager',
-			wifi_dev)
-		getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
-		if current_time_monotonic is None or int(getmanager.Get('org.freedesktop.NetworkManager.Device.Wireless','LastScan')) < current_time_monotonic - 20000:
-			getmanager = dbus.Interface(proxy,dbus_interface='org.freedesktop.NetworkManager.Device.Wireless')
-			getmanager.RequestScan({})
-		getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
-		last_scan_times_monotonic.append(int(getmanager.Get('org.freedesktop.NetworkManager.Device.Wireless','LastScan')))
-	return int(sum(last_scan_times_monotonic) / len(last_scan_times_monotonic))
+    last_scan_times_monotonic = []
+    for wifi_dev in array_of_wifi_devs:
+        proxy = bus.get_object('org.freedesktop.NetworkManager',
+            wifi_dev)
+        getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+        if current_time_monotonic is None or int(getmanager.Get('org.freedesktop.NetworkManager.Device.Wireless','LastScan')) < current_time_monotonic - 20000:
+            getmanager = dbus.Interface(proxy,dbus_interface='org.freedesktop.NetworkManager.Device.Wireless')
+            getmanager.RequestScan({})
+        getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+        last_scan_times_monotonic.append(int(getmanager.Get('org.freedesktop.NetworkManager.Device.Wireless','LastScan')))
+    return int(sum(last_scan_times_monotonic) / len(last_scan_times_monotonic))
+
+def get_battery():
+    proxy = bus.get_object('org.freedesktop.UPower','/org/freedesktop/UPower')
+    getmanager = dbus.Interface(proxy, 'org.freedesktop.UPower')
+    for power_device in getmanager.EnumerateDevices():
+        powerobj = bus.get_object('org.freedesktop.UPower',power_device)
+        powerdev = dbus.Interface(powerobj,'org.freedesktop.DBus.Properties')
+        if powerdev.Get('org.freedesktop.UPower.Device','Type') == 2:
+            return power_device
+    return None
+
+def refresh_power_details(power_device):
+    proxy = bus.get_object('org.freedesktop.UPower',power_device)
+    getmanager = dbus.Interface(proxy, 'org.freedesktop.UPower.Device')
+    getmanager.Refresh()
+    return None
+
+def get_battery_details(power_device):
+    battery_details = {}
+    proxy = bus.get_object('org.freedesktop.UPower',power_device)
+    getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+    battery_details['percent'] = getmanager.Get('org.freedesktop.UPower.Device','Percentage')
+    if int(getmanager.Get('org.freedesktop.UPower.Device','State')) == 1:
+        battery_details['status'] = 'charging'
+    else:
+        battery_details['status'] = 'not-charging'
+    return battery_details
 
 #start a site survey
 #wifi_devices = get_active_wifis()
@@ -80,3 +107,6 @@ def initiate_ap_scan(array_of_wifi_devs, current_time_monotonic=None):
 #active_connection = get_active_wifi_connection()
 #print(human_readable_ap_info(active_connection))
 
+battery = get_battery()
+refresh_power_details(battery)
+print(get_battery_details(battery))

--- a/dbustest.py
+++ b/dbustest.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python3
+
+import dbus
+bus = dbus.SystemBus()
+
+def get_active_wifis():
+	array_of_wifi_devs = []
+	proxy = bus.get_object('org.freedesktop.NetworkManager',
+		'/org/freedesktop/NetworkManager')
+	getmanager = dbus.Interface(proxy, 'org.freedesktop.NetworkManager')
+	devices = getmanager.GetDevices()
+	for device in devices:
+		deviceobject = bus.get_object('org.freedesktop.NetworkManager',device)
+		deviceinterface = dbus.Interface(deviceobject, dbus_interface='org.freedesktop.DBus.Properties')
+		if deviceinterface.Get('org.freedesktop.NetworkManager.Device', 'DeviceType') == 2:
+			array_of_wifi_devs.append(device)
+
+	return array_of_wifi_devs
+
+def get_scan_results(array_of_wifi_devs):
+	array_of_aps = []
+	for device in array_of_wifi_devs:
+		deviceobject = bus.get_object('org.freedesktop.NetworkManager',device)
+		deviceinterface = dbus.Interface(deviceobject, dbus_interface='org.freedesktop.NetworkManager.Device.Wireless')
+		for accesspoint in deviceinterface.GetAllAccessPoints():
+			array_of_aps.append(str(accesspoint))
+	return array_of_aps
+
+def human_readable_ap_info(array_of_aps):
+	array_of_readable_aps = []
+	for accesspoint in array_of_aps:
+		apobject = bus.get_object('org.freedesktop.NetworkManager',accesspoint)
+		apinterface = dbus.Interface(apobject,dbus_interface='org.freedesktop.DBus.Properties')
+		ap = apinterface.GetAll('org.freedesktop.NetworkManager.AccessPoint')
+		ap_info = {}
+		ap_info['name'] = ''.join([chr(byte) for byte in ap['Ssid']])
+		ap_info['strength'] = int(ap['Strength'])
+		if int(ap['Flags']) & 0x1 == 1:
+			ap_info['encrypted'] = True
+		else:
+			ap_info['encrypted'] = False
+		array_of_readable_aps.append(ap_info)
+	return array_of_readable_aps
+
+def get_active_wifi_connection():
+	proxy = bus.get_object('org.freedesktop.NetworkManager',
+		'/org/freedesktop/NetworkManager')
+	getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+	for connection in getmanager.Get('org.freedesktop.NetworkManager', 'ActiveConnections'):
+		connectionobject = bus.get_object('org.freedesktop.NetworkManager',
+					connection)
+		conmanager = dbus.Interface(connectionobject, 'org.freedesktop.DBus.Properties')
+		if conmanager.Get('org.freedesktop.NetworkManager.Connection.Active', 'State') in [1,2,3] and \
+			conmanager.Get('org.freedesktop.NetworkManager.Connection.Active','Type') == '802-11-wireless':
+			return [str(conmanager.Get('org.freedesktop.NetworkManager.Connection.Active','SpecificObject'))]
+
+def initiate_ap_scan(array_of_wifi_devs, current_time_monotonic=None):
+	last_scan_times_monotonic = []
+	for wifi_dev in array_of_wifi_devs:
+		proxy = bus.get_object('org.freedesktop.NetworkManager',
+			wifi_dev)
+		getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+		if current_time_monotonic is None or int(getmanager.Get('org.freedesktop.NetworkManager.Device.Wireless','LastScan')) < current_time_monotonic - 20000:
+			getmanager = dbus.Interface(proxy,dbus_interface='org.freedesktop.NetworkManager.Device.Wireless')
+			getmanager.RequestScan({})
+		getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+		last_scan_times_monotonic.append(int(getmanager.Get('org.freedesktop.NetworkManager.Device.Wireless','LastScan')))
+	return int(sum(last_scan_times_monotonic) / len(last_scan_times_monotonic))
+
+#start a site survey
+#wifi_devices = get_active_wifis()
+#last_scan_time = initiate_ap_scan(wifi_devices)
+
+#read a site survey
+#wifi_devices = get_active_wifis()
+#access_points = get_scan_results(wifi_devices)
+#print(human_readable_ap_info(access_points))
+
+#read existing connection
+#active_connection = get_active_wifi_connection()
+#print(human_readable_ap_info(active_connection))
+

--- a/load.sh
+++ b/load.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 cd /home/chip/pocketchip-menu/
-unclutter &
+#unclutter &
 python3 main.py

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import pygame
 from pygame.locals import *
 

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ class Menu:
     def __init__(self):
         self.size = (480, 272)
         self.fullscreen = IS_LINUX
-        self.screen = pygame.display.set_mode(self.size, self.fullscreen | pygame.DOUBLEBUF)
+        self.screen = pygame.display.set_mode(self.size, self.fullscreen | pygame.DOUBLEBUF | pygame.HWSURFACE)
         self.running = True
         self.visible = True
         self.nav_bar = Nav(self)
@@ -77,6 +77,7 @@ class Menu:
             if self.dialog.visible:
                 self.dialog.draw(page_surface)
         self.screen.blit(page_surface, page_surface.get_rect())
+        pygame.display.update()
 
     def run(self):
         self.pages.append(Power(self))
@@ -90,10 +91,8 @@ class Menu:
                 else:
                     page.visible = False
             self.do(pygame.fastevent.get())
-#            self.update()
 
             self.delta = self.clock.tick(10) / 1000.0
-            pygame.display.update()
         pygame.quit()
         quit()
 

--- a/main.py
+++ b/main.py
@@ -42,8 +42,10 @@ class Menu:
             elif event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_LEFT:
                     self.nav_bar.goToPage(self, "left")
+                    pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
                 elif event.key == pygame.K_RIGHT:
                     self.nav_bar.goToPage(self, "right")
+                    pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
 
             for page in self.pages:
                 if page.visible:
@@ -53,6 +55,9 @@ class Menu:
 
             if self.dialog and self.dialog.visible:
                     self.dialog.do(event)
+            if event.type == pygame.USEREVENT and 'type' in event.__dict__ and event.__dict__['type'] == 'screen_update':
+                self.update()
+                self.draw()
 
     def update(self):
         for page in self.pages:
@@ -85,10 +90,9 @@ class Menu:
                 else:
                     page.visible = False
             self.do(pygame.fastevent.get())
-            self.update()
-            self.draw()
+#            self.update()
 
-            self.delta = self.clock.tick(30) / 1000.0
+            self.delta = self.clock.tick(10) / 1000.0
             pygame.display.update()
         pygame.quit()
         quit()

--- a/main.py
+++ b/main.py
@@ -10,10 +10,8 @@ from Modules.Screens.Apps import *
 from Modules.Screens.Settings import *
 
 if IS_LINUX:
-    from single_process import single_process
     import dbus.mainloop.glib
 
-    single_process()
     main_dbus_loop = dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
     dbus.set_default_main_loop(main_dbus_loop)
 
@@ -21,7 +19,7 @@ if IS_LINUX:
 class Menu:
     pygame.init()
     pygame.display.set_caption('Menu')
-    pygame.event.set_allowed([pygame.QUIT, pygame.KEYDOWN, pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP])
+#    pygame.event.set_allowed([pygame.QUIT, pygame.KEYDOWN, pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP])
     if IS_LINUX:
         pygame.mouse.set_visible(False)
 
@@ -38,25 +36,26 @@ class Menu:
         self.clock = pygame.time.Clock()
         self.dialog = None
 
-    def do(self, event):
-        if event.type == pygame.QUIT:
-            self.running = False
+    def do(self, eventlist):
+        for event in eventlist:
+            if event.type == pygame.QUIT:
+                self.running = False
 
-        elif event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_LEFT:
-                self.nav_bar.goToPage(self, "left")
-            elif event.key == pygame.K_RIGHT:
-                self.nav_bar.goToPage(self, "right")
-        
-        for page in self.pages:
-            if page.visible:
-                page.do(event)
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_LEFT:
+                    self.nav_bar.goToPage(self, "left")
+                elif event.key == pygame.K_RIGHT:
+                    self.nav_bar.goToPage(self, "right")
 
-        self.nav_bar.do(event)
+            for page in self.pages:
+                if page.visible:
+                    page.do(event)
 
-        if self.dialog and self.dialog.visible:
-                self.dialog.do(event)
-            
+            self.nav_bar.do(event)
+
+            if self.dialog and self.dialog.visible:
+                    self.dialog.do(event)
+
     def update(self):
         for page in self.pages:
             if page.visible:
@@ -93,7 +92,7 @@ class Menu:
                     page.visible = True
                 else:
                     page.visible = False
-            self.do(pygame.event.wait())
+            self.do(pygame.fastevent.get())
             self.update()
             self.draw()
 
@@ -105,5 +104,6 @@ class Menu:
 # kick it off
 
 if __name__ == '__main__':
+    pygame.fastevent.init()
     menu = Menu()
     menu.run()

--- a/main.py
+++ b/main.py
@@ -15,11 +15,9 @@ if IS_LINUX:
     main_dbus_loop = dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
     dbus.set_default_main_loop(main_dbus_loop)
 
-
 class Menu:
     pygame.init()
     pygame.display.set_caption('Menu')
-#    pygame.event.set_allowed([pygame.QUIT, pygame.KEYDOWN, pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP])
     if IS_LINUX:
         pygame.mouse.set_visible(False)
 
@@ -61,8 +59,6 @@ class Menu:
             if page.visible:
                 page.update()
 
-        self.nav_bar.update()
-
     def draw(self):
         self.screen.fill((0,0,0,0))
         page_surface = pygame.Surface(self.size, pygame.SRCALPHA)
@@ -70,21 +66,17 @@ class Menu:
             if page.visible:
                 if page.image:
                     page_surface.blit(pygame.image.load(page.image).convert(), (0,0))
-                page.draw(page_surface)  
+                page.draw(page_surface)
         self.nav_bar.draw(page_surface)
         if self.dialog:
             if self.dialog.visible:
-                self.dialog.draw(page_surface) 
+                self.dialog.draw(page_surface)
         self.screen.blit(page_surface, page_surface.get_rect())
-
-        # debug center
-        # pygame.draw.rect(self.screen, (255,255,0), pygame.Rect(self.size[0]/2,self.size[1]/2,0,0),3)
 
     def run(self):
         self.pages.append(Power(self))
         self.pages.append(Apps(self))
         self.pages.append(Settings(self))
-        
 
         while self.running:
             for page in self.pages:
@@ -100,8 +92,6 @@ class Menu:
             pygame.display.update()
         pygame.quit()
         quit()
-
-# kick it off
 
 if __name__ == '__main__':
     pygame.fastevent.init()

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import pygame
 from pygame.locals import *
 
 from Modules.Globals import *
+import Modules.DBusMain
 from Modules.GenWidgets.Nav import *
 from Modules.Screens.Power import *
 from Modules.Screens.Apps import *
@@ -24,7 +25,7 @@ class Menu:
     def __init__(self):
         self.size = (480, 272)
         self.fullscreen = IS_LINUX
-        self.screen = pygame.display.set_mode(self.size, self.fullscreen | pygame.DOUBLEBUF | pygame.HWSURFACE)
+        self.screen = pygame.display.set_mode(self.size, self.fullscreen | pygame.DOUBLEBUF)
         self.running = True
         self.visible = True
         self.nav_bar = Nav(self)
@@ -33,6 +34,8 @@ class Menu:
         self.delta = 0.0
         self.clock = pygame.time.Clock()
         self.dialog = None
+
+        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
 
     def do(self, eventlist):
         for event in eventlist:


### PR DESCRIPTION
This pull request overhauls the screen refresh process to only refresh when something changes. It does so by pulling all events from the queue every frame and processing each one. Any event which changes something on the screen then triggers a user event that triggers a screen refresh.

Additionally, I added threading to the Wifi, Bluetooth and Battery widgets and created a dummy thread which updates each value randomly every few seconds. Each dummy widget triggers a screen refresh on an update (since I'm using threading, I had to switch to the fastevent library which is thread safe).

CPU utilization on my test machine is less than 1% at idle, which is what I'm aiming for.

Note that this pull request actually breaks battery functionality as we're no longer measuring the battery but instead measuring a random value. I'll reimplement it with dbus and fix it in a future update.