### PR TITLE
Add upower to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Still WIP.
 cd ~
 git clone https://github.com/omgmog/pocketchip-menu.git
 cd pocketchip-menu
-sudo apt install unclutter python3-pip python3-pygame python3-dbus
+sudo apt install unclutter python3-pip python3-pygame python3-dbus upower
 sudo pip install -r requirements.txt
 chmod +x load.sh
 mkdir -p /home/chip/.config/awesome/


### PR DESCRIPTION
Upower is not included by default with @macromorgan 's Debian image. Upower needs to be installed for the battery icon to function.